### PR TITLE
Cognito integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+.env
 
 # testing
 /coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "^16.18.23",
         "@types/react": "^18.0.33",
         "@types/react-dom": "^18.0.11",
+        "amazon-cognito-identity-js": "^6.2.0",
         "axios": "^1.3.5",
         "formik": "^2.2.9",
         "react": "^18.2.0",
@@ -56,6 +57,55 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+      "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
+      "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5133,6 +5183,18 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/amazon-cognito-identity-js": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.2.0.tgz",
+      "integrity": "sha512-9Fxrp9+MtLdsJvqOwSaE3ll+pneICeuE3pwj2yDkiyGNWuHx97b8bVLR2bOgfDmDJnY0Hq8QoeXtwdM4aaXJjg==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "buffer": "4.9.2",
+        "fast-base64-decode": "^1.0.0",
+        "isomorphic-unfetch": "^3.0.0",
+        "js-cookie": "^2.2.1"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -5737,6 +5799,25 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5908,10 +5989,25 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/buffer/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
@@ -8326,6 +8422,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9462,6 +9563,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -9992,6 +10112,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -12056,6 +12185,11 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "node_modules/js-sdsl": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
@@ -12712,6 +12846,44 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -16890,6 +17062,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -18089,6 +18266,56 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+      "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+      "requires": {
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
+      "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
+      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "requires": {
+        "tslib": "^2.3.1"
       }
     },
     "@babel/code-frame": {
@@ -21608,6 +21835,18 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "requires": {}
     },
+    "amazon-cognito-identity-js": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.2.0.tgz",
+      "integrity": "sha512-9Fxrp9+MtLdsJvqOwSaE3ll+pneICeuE3pwj2yDkiyGNWuHx97b8bVLR2bOgfDmDJnY0Hq8QoeXtwdM4aaXJjg==",
+      "requires": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "buffer": "4.9.2",
+        "fast-base64-decode": "^1.0.0",
+        "isomorphic-unfetch": "^3.0.0",
+        "js-cookie": "^2.2.1"
+      }
+    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -22058,6 +22297,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -22191,6 +22435,23 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        }
       }
     },
     "buffer-from": {
@@ -23955,6 +24216,11 @@
         }
       }
     },
+    "fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -24777,6 +25043,11 @@
         "harmony-reflect": "^1.4.6"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -25126,6 +25397,15 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
+    },
+    "isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -26634,6 +26914,11 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
       "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg=="
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-sdsl": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
@@ -27127,6 +27412,35 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "node-forge": {
@@ -29980,6 +30294,11 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^16.18.23",
     "@types/react": "^18.0.33",
     "@types/react-dom": "^18.0.11",
+    "amazon-cognito-identity-js": "^6.2.0",
     "axios": "^1.3.5",
     "formik": "^2.2.9",
     "react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { Route, Routes } from "react-router-dom";
 import SignUp from "./routes/authentication/Authentication.component";
-import Verification from "./routes/authentication/components/Verification.component";
 import Navbar from "./shared/ components/Navbar";
 
 const App = () => {
@@ -8,10 +7,9 @@ const App = () => {
     <>
       <Navbar />
       <Routes>
-        {["/sign-in", "/sign-up"].map((path, index) => (
+        {["/sign-in", "/sign-up", "/verification"].map((path, index) => (
           <Route path={path} element={<SignUp />} key={index} />
         ))}
-        <Route path="/verification" element={<Verification />} />
       </Routes>
     </>
   );

--- a/src/routes/authentication/Authentication.component.tsx
+++ b/src/routes/authentication/Authentication.component.tsx
@@ -1,42 +1,56 @@
 import { useState } from "react";
 import FormWrapper from "./components/FormWrapper.component";
 import { useLocation, useNavigate } from "react-router-dom";
+import { CognitoUser, CognitoUserPool } from "amazon-cognito-identity-js";
 import { Container } from "../../shared/ components/Container";
+import LoadingProgress from "../../shared/ components/LoadingProgress";
+import CustomSnackbar, {
+  SnackBarConfig,
+} from "../../shared/ components/Snackbar";
+import { handleSnackbarErrorMessage } from "./utils/auth.utils";
+import {
+  AuthFormFieldsValues,
+  UserPoolData,
+  AuthEnum,
+  SIGN_IN_FORM_FIELDS,
+  SIGN_UP_FORM_FIELDS,
+  VERIFICATION_FORM_FIELDS,
+} from "./types/types.auth";
 
-export enum AuthEnum {
-  SIGN_IN = "sign-in",
-  SIGN_UP = "sign-up",
-}
-
-export type FormField = {
-  name: string;
-  label: string;
-  type: string;
-  sm?: number;
-  xs?: number;
+const initialFormfields = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  password: "",
+  postCode: "",
+  verificationCode: "",
 };
 
-const SIGN_UP_FORM_FIELDS = [
-  { name: "firstName", label: "First Name", type: "text", sm: 6, xs: 12 },
-  { name: "lastName", label: "Last Name", type: "text", sm: 6, xs: 12 },
-  { name: "email", label: "Email", type: "email", xs: 12 },
-  { name: "postCode", label: "Post Code", type: "text", xs: 12 },
-  { name: "password", label: "Password", type: "password", xs: 12 },
-];
-
-const SIGN_IN_FORM_FIELDS = [
-  { name: "email", label: "Email", type: "email", xs: 12 },
-  { name: "password", label: "Password", type: "password", xs: 12 },
-];
-
 const Authentication = () => {
-  const [formFields, setFormFields] = useState({});
+  const [formFields, setFormFields] =
+    useState<AuthFormFieldsValues>(initialFormfields);
+  const [loading, setLoading] = useState(false);
+  const [snackbarConfig, setSnackbarConfig] = useState<SnackBarConfig>();
+
   const location = useLocation();
   const navigate = useNavigate();
 
+  const userPool = new CognitoUserPool(UserPoolData);
+
+  const user = new CognitoUser({
+    Username: formFields.email,
+    Pool: new CognitoUserPool(UserPoolData),
+  });
+
   let authType: AuthEnum = location.pathname.includes("sign-in")
     ? AuthEnum.SIGN_IN
-    : AuthEnum.SIGN_UP;
+    : location.pathname.includes("sign-up")
+    ? AuthEnum.SIGN_UP
+    : AuthEnum.VERIFICATION;
+
+  const handleSnackBarClose = () => {
+    setSnackbarConfig({ ...snackbarConfig, open: false });
+  };
 
   const handleFormFieldChange = (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
@@ -45,15 +59,75 @@ const Authentication = () => {
     setFormFields({ ...formFields, [name]: value });
   };
 
-  const handleSubmitSignUp = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmitSignUp = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    navigate("/verification");
+    setLoading(true);
+    await userPool.signUp(
+      formFields.email,
+      formFields.password,
+      [],
+      [],
+      (error, data) => {
+        if (error) {
+          console.log(error);
+          setSnackbarConfig({
+            message: handleSnackbarErrorMessage(error.message),
+            open: true,
+            type: "error",
+          });
+          setLoading(false);
+          return;
+        }
+
+        navigate("/verification");
+        // axios.post formFields to DB here + remove log
+        console.log(data);
+        setLoading(false);
+        return;
+      }
+    );
+  };
+
+  const handleSubmitVerification = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!formFields.verificationCode) return;
+
+    user.confirmRegistration(
+      formFields.verificationCode,
+      true,
+      (error, data) => {
+        if (error) {
+          console.log(error);
+          setSnackbarConfig({
+            message: handleSnackbarErrorMessage(error.message),
+            open: true,
+            type: "error",
+          });
+          setLoading(false);
+          return;
+        }
+        if (data) {
+          setSnackbarConfig({
+            message: "Account succesfulyy verified!",
+            open: true,
+            type: "success",
+          });
+          setLoading(false);
+          navigate("/sign-in");
+          return;
+        }
+      }
+    );
   };
 
   const handleSubmitSignIn = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(formFields);
+    user.authenticateUser();
   };
+
+  if (loading) {
+    return <LoadingProgress />;
+  }
 
   return (
     <Container>
@@ -64,16 +138,31 @@ const Authentication = () => {
           handleSubmit={(e) => handleSubmitSignIn(e)}
           title="Sign In"
           authType={AuthEnum.SIGN_IN}
+          defaultValues={formFields}
+          buttonText="Sign In"
         />
-      ) : (
+      ) : authType === AuthEnum.SIGN_UP ? (
         <FormWrapper
           handleFormFieldChange={handleFormFieldChange}
           formFields={SIGN_UP_FORM_FIELDS}
           handleSubmit={handleSubmitSignUp}
           title="Sign Up"
           authType={AuthEnum.SIGN_UP}
+          defaultValues={formFields}
+          buttonText="Sign Up"
+        />
+      ) : (
+        <FormWrapper
+          handleFormFieldChange={handleFormFieldChange}
+          formFields={VERIFICATION_FORM_FIELDS}
+          handleSubmit={handleSubmitVerification}
+          title="Verification"
+          authType={AuthEnum.VERIFICATION}
+          buttonText="Verify"
         />
       )}
+
+      <CustomSnackbar config={snackbarConfig} setOpen={handleSnackBarClose} />
     </Container>
   );
 };

--- a/src/routes/authentication/Authentication.component.tsx
+++ b/src/routes/authentication/Authentication.component.tsx
@@ -111,7 +111,7 @@ const Authentication = () => {
         }
         if (data) {
           setSnackbarConfig({
-            message: "Account succesfulyy verified!",
+            message: "Account successfully verified!",
             open: true,
             type: "success",
           });

--- a/src/routes/authentication/components/AuthFormFields.tsx
+++ b/src/routes/authentication/components/AuthFormFields.tsx
@@ -1,15 +1,16 @@
 import { Grid, TextField } from "@mui/material";
-import { FormField } from "../Authentication.component";
+import { FormField, AuthFormFieldsValues } from "../types/types.auth";
 
 type UserFormFieldsProps = {
   formFields: Array<FormField>;
   handleFormFieldChange: (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
   ) => void;
+  defaultValues?: AuthFormFieldsValues;
 };
 
 const AuthFormFields = (props: UserFormFieldsProps) => {
-  const { handleFormFieldChange, formFields } = props;
+  const { handleFormFieldChange, formFields, defaultValues } = props;
 
   const onChange = (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
@@ -25,6 +26,10 @@ const AuthFormFields = (props: UserFormFieldsProps) => {
             <TextField
               name={field.name}
               fullWidth
+              value={
+                defaultValues &&
+                defaultValues[field.name as keyof AuthFormFieldsValues]
+              }
               type={field.type}
               label={field.label}
               onChange={onChange}

--- a/src/routes/authentication/components/FormWrapper.component.tsx
+++ b/src/routes/authentication/components/FormWrapper.component.tsx
@@ -22,6 +22,7 @@ type FormWrapperProps = {
   title: string;
   buttonText: string;
   defaultValues?: AuthFormFieldsValues;
+  handleResendVerificationCode?: () => void;
 };
 
 const StyledBox = styled(Box)`
@@ -53,6 +54,7 @@ const FormWrapper = (props: FormWrapperProps) => {
     title,
     buttonText,
     defaultValues,
+    handleResendVerificationCode,
   } = props;
 
   return (
@@ -78,7 +80,18 @@ const FormWrapper = (props: FormWrapperProps) => {
           >
             {buttonText}
           </StyledButton>
-
+          {authType === AuthEnum.VERIFICATION && (
+            <StyledButton
+              type="button"
+              fullWidth
+              variant="outlined"
+              onClick={() =>
+                handleResendVerificationCode && handleResendVerificationCode()
+              }
+            >
+              Resend code to Email
+            </StyledButton>
+          )}
           <Grid container justifyContent="flex-end">
             <Grid item>
               {authType === AuthEnum.SIGN_UP ? (

--- a/src/routes/authentication/components/FormWrapper.component.tsx
+++ b/src/routes/authentication/components/FormWrapper.component.tsx
@@ -10,7 +10,7 @@ import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import AuthFormFields from "./AuthFormFields";
-import { AuthEnum, FormField } from "../Authentication.component";
+import { FormField, AuthEnum, AuthFormFieldsValues } from "../types/types.auth";
 
 type FormWrapperProps = {
   handleFormFieldChange: (
@@ -20,6 +20,8 @@ type FormWrapperProps = {
   authType: AuthEnum;
   handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   title: string;
+  buttonText: string;
+  defaultValues?: AuthFormFieldsValues;
 };
 
 const StyledBox = styled(Box)`
@@ -43,8 +45,15 @@ const StyledButton = styled(Button)`
 `;
 
 const FormWrapper = (props: FormWrapperProps) => {
-  const { handleFormFieldChange, authType, formFields, handleSubmit, title } =
-    props;
+  const {
+    handleFormFieldChange,
+    authType,
+    formFields,
+    handleSubmit,
+    title,
+    buttonText,
+    defaultValues,
+  } = props;
 
   return (
     <Container component="main" maxWidth="xs">
@@ -59,6 +68,7 @@ const FormWrapper = (props: FormWrapperProps) => {
           <AuthFormFields
             handleFormFieldChange={handleFormFieldChange}
             formFields={formFields}
+            defaultValues={defaultValues}
           />
           <StyledButton
             type="submit"
@@ -66,7 +76,7 @@ const FormWrapper = (props: FormWrapperProps) => {
             variant="contained"
             sx={{ mt: 2 }}
           >
-            {title}
+            {buttonText}
           </StyledButton>
 
           <Grid container justifyContent="flex-end">
@@ -75,10 +85,12 @@ const FormWrapper = (props: FormWrapperProps) => {
                 <StyledLink to="/sign-in">
                   Already have an account? Sign In
                 </StyledLink>
-              ) : (
+              ) : authType === AuthEnum.SIGN_IN ? (
                 <StyledLink to="/sign-up">
                   Don't have an account yet? Sign Up
                 </StyledLink>
+              ) : (
+                <></>
               )}
             </Grid>
           </Grid>

--- a/src/routes/authentication/components/Verification.component.tsx
+++ b/src/routes/authentication/components/Verification.component.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Avatar,
   Box,
@@ -8,6 +9,10 @@ import {
   Typography,
 } from "@mui/material";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+
+type VerificationProps = {
+  email: string;
+};
 
 const StyledAvatarWrapper = styled(Avatar)`
   background-color: var(--color-deep-purple);
@@ -21,7 +26,16 @@ const StyledBox = styled(Box)`
   align-items: center;
 `;
 
-const Verification = () => {
+const Verification = (props: VerificationProps) => {
+  const { email } = props;
+  const [verificationCode, setVerificationCode] = useState<string>();
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+  ) => {
+    setVerificationCode(e.target.value);
+  };
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
   };

--- a/src/routes/authentication/types/types.auth.ts
+++ b/src/routes/authentication/types/types.auth.ts
@@ -1,0 +1,49 @@
+export enum AuthEnum {
+  SIGN_IN = "sign-in",
+  SIGN_UP = "sign-up",
+  VERIFICATION = "verification",
+}
+
+export type AuthFormFieldsValues = {
+  email: string;
+  password: string;
+  postCode: string;
+  firstName: string;
+  lastName: string;
+  verificationCode?: string;
+};
+
+export type FormField = {
+  name: string;
+  label: string;
+  type: string;
+  sm?: number;
+  xs?: number;
+};
+
+export const UserPoolData = {
+  UserPoolId: process.env.REACT_APP_COGNITO_USER_POOL_ID as string,
+  ClientId: process.env.REACT_APP_COGNITO_CLIENT_ID as string,
+};
+
+export const SIGN_UP_FORM_FIELDS: Array<FormField> = [
+  { name: "firstName", label: "First Name", type: "text", sm: 6, xs: 12 },
+  { name: "lastName", label: "Last Name", type: "text", sm: 6, xs: 12 },
+  { name: "email", label: "Email", type: "email", xs: 12 },
+  { name: "postCode", label: "Post Code", type: "text", xs: 12 },
+  { name: "password", label: "Password", type: "password", xs: 12 },
+];
+
+export const VERIFICATION_FORM_FIELDS: Array<FormField> = [
+  {
+    name: "verificationCode",
+    label: "Verification Code",
+    type: "text",
+    xs: 12,
+  },
+];
+
+export const SIGN_IN_FORM_FIELDS: Array<FormField> = [
+  { name: "email", label: "Email", type: "email", xs: 12 },
+  { name: "password", label: "Password", type: "password", xs: 12 },
+];

--- a/src/routes/authentication/utils/auth.utils.tsx
+++ b/src/routes/authentication/utils/auth.utils.tsx
@@ -1,0 +1,15 @@
+export const handleSnackbarErrorMessage = (message: string): string => {
+  if (message.includes("Password not long enough")) {
+    return "Your password must be 8 characters or more.";
+  }
+  if (message.includes("Password must have uppercase characters")) {
+    return "Your password must contain an uppercase character.";
+  }
+  if (message.includes("An account with the given email already exists")) {
+    return "An account with this email address already exists.";
+  }
+  if (message.includes("Invalid verification code provided")) {
+    return "Incorrect code submitted, please try again.";
+  }
+  return "An error occured, please try again later.";
+};

--- a/src/routes/authentication/utils/auth.utils.tsx
+++ b/src/routes/authentication/utils/auth.utils.tsx
@@ -1,4 +1,4 @@
-export const handleSnackbarErrorMessage = (message: string): string => {
+export const handleSnackbarErrorMessage = (message: string) => {
   if (message.includes("Password not long enough")) {
     return "Your password must be 8 characters or more.";
   }
@@ -10,6 +10,12 @@ export const handleSnackbarErrorMessage = (message: string): string => {
   }
   if (message.includes("Invalid verification code provided")) {
     return "Incorrect code submitted, please try again.";
+  }
+  if (message.includes("User is not confirmed.")) {
+    return "Account has not been verified.";
+  }
+  if (message.includes("Incorrect username or password.")) {
+    return message;
   }
   return "An error occured, please try again later.";
 };

--- a/src/shared/ components/LoadingProgress.tsx
+++ b/src/shared/ components/LoadingProgress.tsx
@@ -1,0 +1,12 @@
+import Box from "@mui/material/Box";
+import { LinearProgress } from "@mui/material";
+
+const LoadingProgress = () => {
+  return (
+    <Box sx={{ width: "100%" }}>
+      <LinearProgress />
+    </Box>
+  );
+};
+
+export default LoadingProgress;

--- a/src/shared/ components/Snackbar.tsx
+++ b/src/shared/ components/Snackbar.tsx
@@ -5,7 +5,7 @@ import MuiAlert, { AlertProps } from "@mui/material/Alert";
 export type SnackBarConfig = {
   message?: string;
   open?: boolean;
-  type?: "success" | "error" | "warning";
+  type?: "success" | "error" | "warning" | "info";
 };
 
 type CustomSnackbarProps = {

--- a/src/shared/ components/Snackbar.tsx
+++ b/src/shared/ components/Snackbar.tsx
@@ -1,0 +1,46 @@
+import { forwardRef } from "react";
+import Snackbar from "@mui/material/Snackbar";
+import MuiAlert, { AlertProps } from "@mui/material/Alert";
+
+export type SnackBarConfig = {
+  message?: string;
+  open?: boolean;
+  type?: "success" | "error" | "warning";
+};
+
+type CustomSnackbarProps = {
+  config?: SnackBarConfig;
+  setOpen: (isOpen: boolean) => void;
+};
+
+const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(
+  props,
+  ref
+) {
+  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
+});
+
+const CustomSnackbar = (props: CustomSnackbarProps) => {
+  const { config, setOpen } = props;
+
+  const handleClose = (e?: React.SyntheticEvent | Event, reason?: string) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <Snackbar open={config?.open} autoHideDuration={4000} onClose={handleClose}>
+      <Alert
+        onClose={handleClose}
+        severity={config?.type}
+        sx={{ width: "100%" }}
+      >
+        {config?.message}
+      </Alert>
+    </Snackbar>
+  );
+};
+export default CustomSnackbar;


### PR DESCRIPTION
I'd recommend pulling this branch down locally and giving it a test! 

1) The Authentication component is pretty bulky, hence why I've moved type declarations into its own file. When I move on to building a user context, we could move a lot of the cognito integration to it. 

I do like how the parent level component contains all the API calls and heavy logic, and then calls child components as needed 

2) I've tried to cover off all edge cases, the only one I haven't cracked is to resend the verification code if a user registers, and then trys to login without verifying their account 

3) The verification component has been moved back to being a child of the authentication route/component. This is mainly because it needed some data/props passed to it, and I didn't want to use query strings 


